### PR TITLE
[COURSE] fix SOC104 French final-exam chapter id

### DIFF
--- a/courses/soc104/fr.md
+++ b/courses/soc104/fr.md
@@ -918,7 +918,7 @@ Finalement, Bitcoin n'est pas un projet politique classique, au sens d'une initi
 
 ## Examen final
 
-<chapterId>230ddc56-ceb8-11f0-bf47-6f8dd2541da1</chapterId>
+<chapterId>f776853b-8303-47d9-8327-d925c594564d</chapterId>
 
 <isCourseExam>true</isCourseExam>
 


### PR DESCRIPTION
## Problem

Both `testsync` and `mainsync` fail with a single error:

```
Error processing file(courses2) courses/soc104/bg.md fr.md: PostgresError:
insert or update on table "course_chapters_localized" violates foreign key constraint
"course_chapters_localized_chapter_id_course_chapters_chapter_id"
- Detail: Key (chapter_id)=(230ddc56-ceb8-11f0-bf47-6f8dd2541da1) is not present in table "course_chapters".
```

## Cause

The importer fills `content.course_chapters` only from the first language file of a course (`fileIndex === 0`, alphabetical — `bg.md` here). Every other language then inserts into `course_chapters_localized` with a foreign key to that table.

`courses/soc104/fr.md` chapter 24, "Examen final", carried a freshly generated UUID `230ddc56-ceb8-11f0-bf47-6f8dd2541da1` instead of `f776853b-8303-47d9-8327-d925c594564d`, the id used by the 24 other languages. The localized row therefore had no parent chapter and the whole file was rejected.

Introduced in `7f0d1cfc35 [TRANSLATION] btc101 - Slovak (#4358)`.

## Fix

Align the French chapter id with the shared one. One line.

## Scope check

I swept every course in the repo for the same defect class — `chapterId` and `partId` values present in a translation but absent from its reference file. `soc104/fr.md` is the only real case. Remaining scan hits were `presentation.md` files, which are not language files, and `his204/cs.md`, an incomplete translation (missing chapters are fine; only extra ids break the FK).

After this change, `soc104` chapter ids are consistent across all 25 languages.